### PR TITLE
Remove base2 package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1666,7 +1666,6 @@ dependencies = [
 name = "sync-committee-verifier"
 version = "0.1.0"
 dependencies = [
- "base2",
  "ethereum-consensus",
  "log",
  "milagro_bls",

--- a/primitives/src/types.rs
+++ b/primitives/src/types.rs
@@ -15,6 +15,12 @@ pub const BLOCK_ROOTS_INDEX: u64 = 37;
 pub const HISTORICAL_ROOTS_INDEX: u64 = 39;
 pub const HISTORICAL_BATCH_BLOCK_ROOTS_INDEX: u64 = 2;
 pub const EXECUTION_PAYLOAD_TIMESTAMP_INDEX: u64 = 25;
+pub const FINALIZED_ROOT_INDEX_LOG2: u64 = 5;
+pub const EXECUTION_PAYLOAD_INDEX_LOG2: u64 = 5;
+pub const NEXT_SYNC_COMMITTEE_INDEX_LOG2: u64 = 5;
+pub const BLOCK_ROOTS_INDEX_LOG2: u64 = 5;
+pub const HISTORICAL_ROOTS_INDEX_LOG2: u64 = 5;
+
 #[cfg(not(feature = "testing"))]
 pub const GENESIS_VALIDATORS_ROOT: [u8; 32] =
 	hex_literal::hex!("4b363db94e286120d76eb905340fdd4e54bfe9f06bf33ff6cf5ad27f511bfe95");

--- a/verifier/Cargo.toml
+++ b/verifier/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 authors = ["Polytope Labs"]
 
 [dependencies]
-base2 = { version="0.2.2", default-features = false }
 sync-committee-primitives = { path= "../primitives", default-features = false }
 ethereum-consensus = { git = "https://github.com/polytope-labs/ethereum-consensus", rev = "d3fe0ad76613b52cdfbdea7c317ecdc35f271e4f", default-features = false }
 ssz-rs = { git = "https://github.com/polytope-labs/ssz-rs", rev = "2e28a8800787392045fb3f8f1eaef6c65a8600d7", default-features = false }


### PR DESCRIPTION
base2 package causes wasm build errors when this package is imported in other places